### PR TITLE
Linux ca-cert directory issue

### DIFF
--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -31,6 +31,8 @@ export default class LinuxPlatform implements Platform {
   async addToTrustStores(certificatePath: string, options: Options = {}): Promise<void> {
 
     debug('Adding devcert root CA to Linux system-wide trust stores');
+    // Ensure the certificate path actually exists on system:
+    run(`sudo mkdir -p /usr/local/share/ca-certificates/`);
     // run(`sudo cp ${ certificatePath } /etc/ssl/certs/devcert.crt`);
     run(`sudo cp ${ certificatePath } /usr/local/share/ca-certificates/devcert.crt`);
     // run(`sudo bash -c "cat ${ certificatePath } >> /etc/ssl/certs/ca-certificates.crt"`);


### PR DESCRIPTION
Added a line to ensure path exists on Linux during cert creation for systems with Firefox .
If the path doesn't exist, this causes an issue.